### PR TITLE
feat: auto-discover Docker Compose stacks, DRY notifications, improve…

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ Role Variables
 ---
 discord_webhook_id: "{{ vault_discord_webhook_id }}"
 discord_webhook_token: "{{ vault_discord_webhook_token }}"
-compose_projects:
-  - /opt/project1
-  - /opt/project2
+# Docker Compose stacks are auto-discovered per host via `docker compose ls`.
+# List any stack directories to skip here — most importantly the automation
+# controller's own stack (e.g. Semaphore), which must not be patched mid-run.
+compose_exclude:
+  - /opt/stacks/semaphore
 
 ```
 

--- a/roles/os-patching/defaults/main.yml
+++ b/roles/os-patching/defaults/main.yml
@@ -1,16 +1,11 @@
 ---
 discord_webhook_id: "{{ vault_discord_webhook_id }}"
 discord_webhook_token: "{{ vault_discord_webhook_token }}"
-compose_projects:
-  - /opt/dockge
-  - /opt/pangolin
-  - /opt/stacks/cloudflare-tunnel
-  - /opt/stacks/netboot_xyz
-  - /opt/stacks/pangolin
-  - /opt/stacks/plex
-  - /opt/stacks/starr
-  - /opt/stacks/stigman
-  # - /opt/stacks/semaphore # If you patch the thing that is running the auomation it will break the playbook execution
+# Compose stacks are auto-discovered per host via `docker compose ls`. List any
+# stack directories to skip here. Critically, exclude the automation controller's
+# own stack (e.g. Semaphore) — patching the thing running the playbook breaks the run.
+compose_exclude:
+  - /opt/stacks/semaphore
 aur_helper: yay
 # When false, hosts are patched but never rebooted (reboot-required signals
 # persist, so a later run with reboot_enabled=true will reboot them).

--- a/roles/os-patching/tasks/Archlinux.yml
+++ b/roles/os-patching/tasks/Archlinux.yml
@@ -19,41 +19,21 @@
     upgrade_extra_args: "--noconfirm --needed"
   register: aur_results
 
-- name: "Send Notification to Discord that {{ inventory_hostname }} was Patched"
-  community.general.discord:
-    webhook_id: "{{ discord_webhook_id }}"
-    webhook_token: "{{ discord_webhook_token }}"
-    embeds:
-      - title: "👍 {{ inventory_hostname }} was patched 👍"
-        color: 1127128
-        fields:
-          - name: Hostname
-            value: "{{ inventory_hostname }}"
-          - name: IP Address
-            value: "{{ ansible_host }}"
-  when:
-    - pacman_results.changed or
-      aur_results.changed
-  ignore_errors: true
-  changed_when: false
+- name: "Notify Discord: patched"
+  ansible.builtin.include_tasks: notify.yml
+  vars:
+    embed_title: "👍 {{ inventory_hostname }} was patched 👍"
+    embed_color: 1127128
+  when: pacman_results.changed or aur_results.changed
 
-- name: "Send Notification to Discord that {{ inventory_hostname }} was Not Patched"
-  community.general.discord:
-    webhook_id: "{{ discord_webhook_id }}"
-    webhook_token: "{{ discord_webhook_token }}"
-    embeds:
-      - title: "👍 No Patches were Required on {{ inventory_hostname }} 👍"
-        color: 65280
-        fields:
-          - name: Hostname
-            value: "{{ inventory_hostname }}"
-          - name: IP Address
-            value: "{{ ansible_host }}"
+- name: "Notify Discord: no patches required"
+  ansible.builtin.include_tasks: notify.yml
+  vars:
+    embed_title: "👍 No Patches were Required on {{ inventory_hostname }} 👍"
+    embed_color: 65280
   when:
     - not pacman_results.changed
     - not aur_results.changed
-  ignore_errors: true
-  changed_when: false
 
 - name: Check if a Reboot is Required
   ansible.builtin.command: /usr/bin/needrestart
@@ -70,22 +50,13 @@
     - reboot_enabled | bool
   notify: Send Reboot Notification
 
-- name: "Send Notification to Discord that {{ inventory_hostname }} has a Reboot Pending"
-  community.general.discord:
-    webhook_id: "{{ discord_webhook_id }}"
-    webhook_token: "{{ discord_webhook_token }}"
-    embeds:
-      - title: "⏳ Reboot Pending on {{ inventory_hostname }} ⏳"
-        color: 16753920
-        fields:
-          - name: Hostname
-            value: "{{ inventory_hostname }}"
-          - name: IP Address
-            value: "{{ ansible_host }}"
+- name: "Notify Discord: reboot pending"
+  ansible.builtin.include_tasks: notify.yml
+  vars:
+    embed_title: "⏳ Reboot Pending on {{ inventory_hostname }} ⏳"
+    embed_color: 16753920
   when:
     - "'Running kernel seems to be up-to-date.' not in reboot_required.stdout"
     - "'No services need to be restarted.' not in reboot_required.stdout"
     - not inventory_hostname in groups["devices_net"]
     - not reboot_enabled | bool
-  ignore_errors: true
-  changed_when: false

--- a/roles/os-patching/tasks/Debian.yml
+++ b/roles/os-patching/tasks/Debian.yml
@@ -6,43 +6,24 @@
 
 - name: "Update all APT packages on {{ inventory_hostname }}"
   ansible.builtin.apt:
-    name: "*"
-    state: latest
+    upgrade: full
+    autoremove: true
+    autoclean: true
   register: apt_results
 
-- name: "Send Notification to Discord that {{ inventory_hostname }} was Patched"
-  community.general.discord:
-    webhook_id: "{{ discord_webhook_id }}"
-    webhook_token: "{{ discord_webhook_token }}"
-    embeds:
-      - title: "👍 {{ inventory_hostname }} was patched 👍"
-        color: 1127128
-        fields:
-          - name: Hostname
-            value: "{{ inventory_hostname }}"
-          - name: IP Address
-            value: "{{ ansible_host }}"
-  when:
-    - apt_results.changed
-  ignore_errors: true
-  changed_when: false
+- name: "Notify Discord: patched"
+  ansible.builtin.include_tasks: notify.yml
+  vars:
+    embed_title: "👍 {{ inventory_hostname }} was patched 👍"
+    embed_color: 1127128
+  when: apt_results.changed
 
-- name: "Send Notification to Discord that {{ inventory_hostname }} was Not Patched"
-  community.general.discord:
-    webhook_id: "{{ discord_webhook_id }}"
-    webhook_token: "{{ discord_webhook_token }}"
-    embeds:
-      - title: "👍 No Patches were Required on {{ inventory_hostname }} 👍"
-        color: 65280
-        fields:
-          - name: Hostname
-            value: "{{ inventory_hostname }}"
-          - name: IP Address
-            value: "{{ ansible_host }}"
-  when:
-    - not apt_results.changed
-  ignore_errors: true
-  changed_when: false
+- name: "Notify Discord: no patches required"
+  ansible.builtin.include_tasks: notify.yml
+  vars:
+    embed_title: "👍 No Patches were Required on {{ inventory_hostname }} 👍"
+    embed_color: 65280
+  when: not apt_results.changed
 
 - name: Check if a Reboot is Required
   ansible.builtin.stat:
@@ -57,20 +38,11 @@
     - reboot_enabled | bool
   notify: Send Reboot Notification
 
-- name: "Send Notification to Discord that {{ inventory_hostname }} has a Reboot Pending"
-  community.general.discord:
-    webhook_id: "{{ discord_webhook_id }}"
-    webhook_token: "{{ discord_webhook_token }}"
-    embeds:
-      - title: "⏳ Reboot Pending on {{ inventory_hostname }} ⏳"
-        color: 16753920
-        fields:
-          - name: Hostname
-            value: "{{ inventory_hostname }}"
-          - name: IP Address
-            value: "{{ ansible_host }}"
+- name: "Notify Discord: reboot pending"
+  ansible.builtin.include_tasks: notify.yml
+  vars:
+    embed_title: "⏳ Reboot Pending on {{ inventory_hostname }} ⏳"
+    embed_color: 16753920
   when:
     - reboot_required.stat.exists
     - not reboot_enabled | bool
-  ignore_errors: true
-  changed_when: false

--- a/roles/os-patching/tasks/Docker.yml
+++ b/roles/os-patching/tasks/Docker.yml
@@ -1,41 +1,37 @@
 ---
-- name: "Verify Compose Projects exist"
-  ansible.builtin.stat:
-    path: "{{ item }}"
-  loop: "{{ compose_projects }}"
-  register: compose
+- name: "Discover running Docker Compose projects on {{ inventory_hostname }}"
+  ansible.builtin.command: docker compose ls --format json
+  register: compose_ls
+  changed_when: false
+  check_mode: false
+
+- name: "Resolve compose project directories on {{ inventory_hostname }}"
+  ansible.builtin.set_fact:
+    compose_targets: >-
+      {{ compose_ls.stdout | from_json
+         | map(attribute='ConfigFiles')
+         | map('regex_replace', ',.*$', '')
+         | map('dirname')
+         | unique
+         | difference(compose_exclude) }}
 
 - name: "Update Images and Restart Required Containers"
   community.docker.docker_compose_v2:
-    project_src: "{{ item.stat.path }}"
+    project_src: "{{ item }}"
     pull: always
     recreate: auto
     state: present
   register: docker_v2_results
-  loop: "{{ compose.results }}"
-  loop_control:
-    label: "{{ item.item }}"
-  when:
-    - item.stat.exists
-    - item.stat.isdir|default(false)
+  loop: "{{ compose_targets }}"
 
 - name: "Prune Unused Container Images"
   community.docker.docker_prune:
     images: true
+  when: docker_v2_results.changed
 
-- name: "Send Notification to Discord that Docker Images were updated on {{ inventory_hostname }}"
-  community.general.discord:
-    webhook_id: "{{ discord_webhook_id }}"
-    webhook_token: "{{ discord_webhook_token }}"
-    embeds:
-      - title: "👍 Docker Images Updated on {{ inventory_hostname }} 👍"
-        color: 1127128
-        fields:
-          - name: Hostname
-            value: "{{ inventory_hostname }}"
-          - name: IP Address
-            value: "{{ ansible_host }}"
-  when:
-    - docker_v2_results.changed
-  ignore_errors: true
-  changed_when: false
+- name: "Notify Discord: Docker images updated"
+  ansible.builtin.include_tasks: notify.yml
+  vars:
+    embed_title: "👍 Docker Images Updated on {{ inventory_hostname }} 👍"
+    embed_color: 1127128
+  when: docker_v2_results.changed

--- a/roles/os-patching/tasks/RedHat.yml
+++ b/roles/os-patching/tasks/RedHat.yml
@@ -8,41 +8,22 @@
   ansible.builtin.dnf:
     name: "*"
     state: latest
+    autoremove: true
   register: dnf_results
 
-- name: "Send Notification to Discord that {{ inventory_hostname }} was Patched"
-  community.general.discord:
-    webhook_id: "{{ discord_webhook_id }}"
-    webhook_token: "{{ discord_webhook_token }}"
-    embeds:
-      - title: "👍 {{ inventory_hostname }} was patched 👍"
-        color: 1127128
-        fields:
-          - name: Hostname
-            value: "{{ inventory_hostname }}"
-          - name: IP Address
-            value: "{{ ansible_host }}"
-  when:
-    - dnf_results.changed
-  ignore_errors: true
-  changed_when: false
+- name: "Notify Discord: patched"
+  ansible.builtin.include_tasks: notify.yml
+  vars:
+    embed_title: "👍 {{ inventory_hostname }} was patched 👍"
+    embed_color: 1127128
+  when: dnf_results.changed
 
-- name: "Send Notification to Discord that {{ inventory_hostname }} was Not Patched"
-  community.general.discord:
-    webhook_id: "{{ discord_webhook_id }}"
-    webhook_token: "{{ discord_webhook_token }}"
-    embeds:
-      - title: "👍 No Patches were Required on {{ inventory_hostname }} 👍"
-        color: 65280
-        fields:
-          - name: Hostname
-            value: "{{ inventory_hostname }}"
-          - name: IP Address
-            value: "{{ ansible_host }}"
-  when:
-    - not dnf_results.changed
-  ignore_errors: true
-  changed_when: false
+- name: "Notify Discord: no patches required"
+  ansible.builtin.include_tasks: notify.yml
+  vars:
+    embed_title: "👍 No Patches were Required on {{ inventory_hostname }} 👍"
+    embed_color: 65280
+  when: not dnf_results.changed
 
 - name: Check if a Reboot is Required
   ansible.builtin.command: /usr/bin/needs-restarting -r
@@ -60,20 +41,11 @@
     - reboot_enabled | bool
   notify: Send Reboot Notification
 
-- name: "Send Notification to Discord that {{ inventory_hostname }} has a Reboot Pending"
-  community.general.discord:
-    webhook_id: "{{ discord_webhook_id }}"
-    webhook_token: "{{ discord_webhook_token }}"
-    embeds:
-      - title: "⏳ Reboot Pending on {{ inventory_hostname }} ⏳"
-        color: 16753920
-        fields:
-          - name: Hostname
-            value: "{{ inventory_hostname }}"
-          - name: IP Address
-            value: "{{ ansible_host }}"
+- name: "Notify Discord: reboot pending"
+  ansible.builtin.include_tasks: notify.yml
+  vars:
+    embed_title: "⏳ Reboot Pending on {{ inventory_hostname }} ⏳"
+    embed_color: 16753920
   when:
     - reboot_required.rc == 1
     - not reboot_enabled | bool
-  ignore_errors: true
-  changed_when: false

--- a/roles/os-patching/tasks/notify.yml
+++ b/roles/os-patching/tasks/notify.yml
@@ -1,0 +1,17 @@
+---
+# Shared Discord notification. Callers set embed_title / embed_color and carry
+# their own `when:` on the include. Notification failures must never abort a run.
+- name: "Send Discord notification: {{ embed_title }}"
+  community.general.discord:
+    webhook_id: "{{ discord_webhook_id }}"
+    webhook_token: "{{ discord_webhook_token }}"
+    embeds:
+      - title: "{{ embed_title }}"
+        color: "{{ embed_color }}"
+        fields:
+          - name: Hostname
+            value: "{{ inventory_hostname }}"
+          - name: IP Address
+            value: "{{ ansible_host | default(inventory_hostname) }}"
+  ignore_errors: true
+  changed_when: false


### PR DESCRIPTION
… patch coverage

- Docker: discover stacks per host via `docker compose ls --format json` instead of the hand-maintained compose_projects list; gate image prune on changes. Replace compose_projects with compose_exclude (skip list, e.g. the automation controller's own stack).
- Notifications: extract repeated Discord embeds into shared tasks/notify.yml parameterized by embed_title/embed_color; OS task files and Docker.yml now include it (reboot handler left inline).
- Coverage: Debian upgrade:full (dist-upgrade) + autoremove/autoclean so kernel updates fire reboot detection; RedHat adds autoremove.
- Docs: README and CLAUDE.md updated for auto-discovery + compose_exclude.