### PR TITLE
fix(docker): clearer "manual restart needed" Discord embed

### DIFF
--- a/roles/os-patching/tasks/Docker.yml
+++ b/roles/os-patching/tasks/Docker.yml
@@ -72,13 +72,17 @@
 - name: "Notify Discord: excluded stacks have updates pending manual restart"
   ansible.builtin.include_tasks: notify.yml
   vars:
-    embed_title: "🛠️ Manual Action Needed on {{ inventory_hostname }} 🛠️"
+    embed_title: "🛠️ Manual Restart Needed: {{ inventory_hostname }}"
     embed_color: 16753920
     embed_description: >-
-      New images were pulled for these excluded stacks, but they were NOT
-      restarted — reconstitute them manually to apply the update:
-      {{ compose_pull_results.results | default([])
-         | selectattr('changed') | map(attribute='item') | join(', ') }}
+      New images were pulled but these stacks were not restarted.
+      To apply the update, run `docker compose up -d` in each directory below.
+    embed_extra_fields:
+      - name: "Stack(s) to Restart"
+        value: >-
+          {{ compose_pull_results.results | default([])
+             | selectattr('changed') | map(attribute='item')
+             | map('regex_replace', '^(.*)$', '• \1') | join('\n') }}
   when: >-
     compose_pull_results.results | default([])
     | selectattr('changed') | list | length > 0

--- a/roles/os-patching/tasks/notify.yml
+++ b/roles/os-patching/tasks/notify.yml
@@ -1,6 +1,8 @@
 ---
 # Shared Discord notification. Callers set embed_title / embed_color and carry
-# their own `when:` on the include. Notification failures must never abort a run.
+# their own `when:` on the include. Optionally pass embed_description and
+# embed_extra_fields (list of {name, value}) to append below the host fields.
+# Notification failures must never abort a run.
 - name: "Send Discord notification: {{ embed_title }}"
   community.general.discord:
     webhook_id: "{{ discord_webhook_id }}"
@@ -9,10 +11,8 @@
       - title: "{{ embed_title }}"
         color: "{{ embed_color }}"
         description: "{{ embed_description | default(omit) }}"
-        fields:
-          - name: Hostname
-            value: "{{ inventory_hostname }}"
-          - name: IP Address
-            value: "{{ ansible_host | default(inventory_hostname) }}"
+        fields: "{{ [{'name': 'Hostname', 'value': inventory_hostname},
+                     {'name': 'IP Address', 'value': ansible_host | default(inventory_hostname)}]
+                    + (embed_extra_fields | default([])) }}"
   ignore_errors: true
   changed_when: false


### PR DESCRIPTION
The manual-action embed buried the affected stacks in a run-on description. Add optional embed_extra_fields to notify.yml and use it to show each stack needing a restart on its own line in a dedicated field, with a short description telling the user to run `docker compose up -d` in each directory.