### PR TITLE
feat(docker): drift-based pending-restart detection + daily reminder playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ Example Playbook
 
 ```
 
+Pending Restart Reminders
+-------------------------
+
+Stacks listed in `compose_exclude` (e.g. the automation controller's own stack) get their images
+pulled during patching but are never restarted automatically. `report-pending-restarts.yml` is a
+read-only playbook that reports — via Discord — any stack running an outdated image (a newer image
+was pulled but not applied). It does not patch, pull, or restart anything, and is self-clearing
+once the stack is restarted with `docker compose up -d`. Schedule it daily (e.g. a Semaphore
+template schedule) as a recurring reminder.
+
+`ansible-playbook -i inventory.yml report-pending-restarts.yml -K --ask-vault-pass`
+
 License
 -------
 

--- a/report-pending-restarts.yml
+++ b/report-pending-restarts.yml
@@ -1,0 +1,16 @@
+---
+# Read-only reminder run: reports (via Discord) any Docker Compose stack that is
+# running an outdated image — a newer image was pulled during patching but the
+# stack was never restarted onto it (e.g. the excluded automation controller, or
+# a managed stack whose recreate failed). Does NOT patch, pull, or restart.
+#
+# Schedule this daily (Semaphore template schedule, cron, etc.) to keep nagging
+# until someone runs `docker compose up -d`. The check is self-clearing.
+- name: Report Docker Compose stacks pending a manual restart
+  hosts: all
+  become: true
+  tasks:
+    - name: "Check for stacks running outdated images"
+      ansible.builtin.include_role:
+        name: os-patching
+        tasks_from: report_pending_restarts

--- a/roles/os-patching/files/compose_drift.sh
+++ b/roles/os-patching/files/compose_drift.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Print the project directory of any compose stack whose running containers are
+# using an image older than the latest image available locally — i.e. a newer
+# image has been pulled but the stack has not been recreated onto it.
+#
+# Usage: compose_drift.sh <project_dir> [<project_dir> ...]
+#
+# Self-clearing: once a stack is restarted (docker compose up -d) the running
+# container adopts the latest image ID and is no longer reported.
+
+for dir in "$@"; do
+  stale=""
+  for cid in $(docker compose --project-directory "$dir" ps -q 2>/dev/null); do
+    running=$(docker inspect --format '{{.Image}}' "$cid" 2>/dev/null) || continue
+    ref=$(docker inspect --format '{{.Config.Image}}' "$cid" 2>/dev/null) || continue
+    [ -n "$ref" ] || continue
+    latest=$(docker image inspect --format '{{.Id}}' "$ref" 2>/dev/null) || continue
+    if [ -n "$latest" ] && [ "$running" != "$latest" ]; then
+      stale=1
+    fi
+  done
+  if [ -n "$stale" ]; then
+    echo "$dir"
+  fi
+done

--- a/roles/os-patching/tasks/Docker.yml
+++ b/roles/os-patching/tasks/Docker.yml
@@ -1,27 +1,6 @@
 ---
-- name: "Discover running Docker Compose projects on {{ inventory_hostname }}"
-  ansible.builtin.command: docker compose ls --format json
-  register: compose_ls
-  changed_when: false
-  check_mode: false
-
-- name: "Resolve discovered compose project directories on {{ inventory_hostname }}"
-  ansible.builtin.set_fact:
-    compose_discovered: >-
-      {{ compose_ls.stdout | from_json
-         | map(attribute='ConfigFiles')
-         | map('regex_replace', ',.*$', '')
-         | map('dirname')
-         | unique | list }}
-
-# compose_targets are fully managed (pull + recreate); compose_pull_only are
-# excluded stacks present on this host — we pull their images but never restart
-# them (e.g. the automation controller itself), and report any updates so they
-# can be reconstituted manually.
-- name: "Partition compose projects into managed vs pull-only on {{ inventory_hostname }}"
-  ansible.builtin.set_fact:
-    compose_targets: "{{ compose_discovered | difference(compose_exclude) }}"
-    compose_pull_only: "{{ compose_discovered | intersect(compose_exclude) }}"
+- name: "Discover and partition compose stacks on {{ inventory_hostname }}"
+  ansible.builtin.include_tasks: discover_compose.yml
 
 - name: "Update Images and Restart Required Containers"
   community.docker.docker_compose_v2:
@@ -65,24 +44,13 @@
   community.docker.docker_compose_v2_pull:
     project_src: "{{ item }}"
     policy: always
-  register: compose_pull_results
   loop: "{{ compose_pull_only }}"
   ignore_errors: true
 
-- name: "Notify Discord: excluded stacks have updates pending manual restart"
-  ansible.builtin.include_tasks: notify.yml
+# Report any stack now running an outdated image — typically the excluded
+# pull-only stacks (pulled but not restarted), or a managed stack whose recreate
+# failed above. Drift-based so it keeps reminding until the stack is restarted.
+- name: "Report stacks running outdated images on {{ inventory_hostname }}"
+  ansible.builtin.include_tasks: check_drift.yml
   vars:
-    embed_title: "🛠️ Manual Restart Needed: {{ inventory_hostname }}"
-    embed_color: 16753920
-    embed_description: >-
-      New images were pulled but these stacks were not restarted.
-      To apply the update, run `docker compose up -d` in each directory below.
-    embed_extra_fields:
-      - name: "Stack(s) to Restart"
-        value: >-
-          {{ compose_pull_results.results | default([])
-             | selectattr('changed') | map(attribute='item')
-             | map('regex_replace', '^(.*)$', '• \1') | join('\n') }}
-  when: >-
-    compose_pull_results.results | default([])
-    | selectattr('changed') | list | length > 0
+    drift_projects: "{{ compose_discovered }}"

--- a/roles/os-patching/tasks/check_drift.yml
+++ b/roles/os-patching/tasks/check_drift.yml
@@ -1,0 +1,26 @@
+---
+# Flag compose stacks running outdated images (a newer image was pulled locally
+# but the running container has not been recreated onto it). Self-clearing: once
+# the stack is restarted it stops being reported. Caller sets `drift_projects`
+# (list of project directories to check).
+- name: "Detect compose image drift on {{ inventory_hostname }}"
+  ansible.builtin.script: "compose_drift.sh {{ drift_projects | map('quote') | join(' ') }}"
+  register: drift_check
+  changed_when: false
+  check_mode: false
+  when: drift_projects | length > 0
+
+- name: "Notify Discord: stacks running outdated images need a manual restart"
+  ansible.builtin.include_tasks: notify.yml
+  vars:
+    embed_title: "🛠️ Manual Restart Needed: {{ inventory_hostname }}"
+    embed_color: 16753920
+    embed_description: >-
+      These stacks are running outdated images (a newer image was pulled but
+      not yet applied). Run `docker compose up -d` in each directory below.
+    embed_extra_fields:
+      - name: "Stack(s) to Restart"
+        value: >-
+          {{ drift_check.stdout_lines | default([])
+             | map('regex_replace', '^(.*)$', '• \1') | join('\n') }}
+  when: drift_check.stdout_lines | default([]) | length > 0

--- a/roles/os-patching/tasks/discover_compose.yml
+++ b/roles/os-patching/tasks/discover_compose.yml
@@ -1,0 +1,24 @@
+---
+# Discover the host's running compose stacks and partition them. Sets:
+#   compose_discovered - all discovered project directories
+#   compose_targets    - fully managed (recreated): discovered minus compose_exclude
+#   compose_pull_only  - excluded stacks present on the host (pulled, not restarted)
+- name: "Discover running Docker Compose projects on {{ inventory_hostname }}"
+  ansible.builtin.command: docker compose ls --format json
+  register: compose_ls
+  changed_when: false
+  check_mode: false
+
+- name: "Resolve discovered compose project directories on {{ inventory_hostname }}"
+  ansible.builtin.set_fact:
+    compose_discovered: >-
+      {{ compose_ls.stdout | from_json
+         | map(attribute='ConfigFiles')
+         | map('regex_replace', ',.*$', '')
+         | map('dirname')
+         | unique | list }}
+
+- name: "Partition compose projects into managed vs pull-only on {{ inventory_hostname }}"
+  ansible.builtin.set_fact:
+    compose_targets: "{{ compose_discovered | difference(compose_exclude) }}"
+    compose_pull_only: "{{ compose_discovered | intersect(compose_exclude) }}"

--- a/roles/os-patching/tasks/report_pending_restarts.yml
+++ b/roles/os-patching/tasks/report_pending_restarts.yml
@@ -1,0 +1,22 @@
+---
+# Read-only entry point (no patching, no pulling): discover the host's compose
+# stacks and report any that are running outdated images and need a manual
+# restart. Intended to be run on a schedule (e.g. daily) as a recurring reminder.
+- name: "Prelim | Include Vaulted Variables"
+  ansible.builtin.include_vars: vault.yml
+
+- name: "Prelim | Verify host has Docker installed"
+  ansible.builtin.stat:
+    path: /usr/bin/docker
+  register: docker
+
+- name: "Report compose stacks pending a manual restart on {{ inventory_hostname }}"
+  when: docker.stat.exists and docker.stat.isreg
+  block:
+    - name: "Discover compose stacks"
+      ansible.builtin.include_tasks: discover_compose.yml
+
+    - name: "Check all discovered stacks for image drift"
+      ansible.builtin.include_tasks: check_drift.yml
+      vars:
+        drift_projects: "{{ compose_discovered }}"


### PR DESCRIPTION
## What

Detects Docker Compose stacks that are **running an outdated image** — a newer image was pulled (during patching) but the stack was never recreated onto it — and reports them via Discord. Replaces the previous one-shot pull-`changed` trigger, which went silent on subsequent runs even if nobody restarted.

## How

`roles/os-patching/files/compose_drift.sh` compares, per running container, the image ID it's actually running (`docker inspect {{.Image}}`) against the latest image ID locally available for its tag (`docker image inspect {{.Id}}`). A mismatch = stale. This is **self-clearing**: once someone runs `docker compose up -d`, the IDs match and the stack stops being reported.

## Changes

- **`files/compose_drift.sh`** — drift-detection script.
- **`discover_compose.yml`** — discovery/partition extracted from `Docker.yml` so it's reused by both the patch run and the reminder.
- **`check_drift.yml`** — runs the script and posts the 🛠️ "Manual Restart Needed" embed listing stale stacks (each on its own line).
- **`Docker.yml`** — runs the drift check over all discovered stacks at the end of the patch run (covers pull-only/excluded stacks *and* any managed stack whose recreate failed).
- **`report-pending-restarts.yml`** + **`report_pending_restarts.yml`** — read-only playbook (discover + drift-check only, no patching/pulling/restarting) intended to be **scheduled daily** (e.g. a Semaphore template schedule) as a recurring reminder.
- Docs (README, CLAUDE.md) updated.

## Verification

- `ansible-playbook apply-patches.yml --syntax-check` and `report-pending-restarts.yml --syntax-check` both pass.
- `bash -n` on the script passes.
- Lint adds no new findings vs. baseline.
- The `script` task is `check_mode: false` (read-only), so a `--check` run of `report-pending-restarts.yml` safely previews real drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)