### PR TITLE
harden: no_log on secret-handling tasks; default ansible_host in reboot handler

### DIFF
--- a/roles/os-patching/handlers/main.yml
+++ b/roles/os-patching/handlers/main.yml
@@ -10,5 +10,6 @@
           - name: Hostname
             value: "{{ inventory_hostname }}"
           - name: IP Address
-            value: "{{ ansible_host }}"
+            value: "{{ ansible_host | default(inventory_hostname) }}"
   ignore_errors: true
+  no_log: true

--- a/roles/os-patching/tasks/main.yml
+++ b/roles/os-patching/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Prelim | Include Vaulted Variables
   ansible.builtin.include_vars: vault.yml
+  no_log: true
 
 - name: "Prelim | Verify need-restarting Command is Present on {{ inventory_hostname }}"
   ansible.builtin.dnf:

--- a/roles/os-patching/tasks/notify.yml
+++ b/roles/os-patching/tasks/notify.yml
@@ -16,3 +16,4 @@
                     + (embed_extra_fields | default([])) }}"
   ignore_errors: true
   changed_when: false
+  no_log: true

--- a/roles/os-patching/tasks/report_pending_restarts.yml
+++ b/roles/os-patching/tasks/report_pending_restarts.yml
@@ -4,6 +4,7 @@
 # restart. Intended to be run on a schedule (e.g. daily) as a recurring reminder.
 - name: "Prelim | Include Vaulted Variables"
   ansible.builtin.include_vars: vault.yml
+  no_log: true
 
 - name: "Prelim | Verify host has Docker installed"
   ansible.builtin.stat:


### PR DESCRIPTION
## Summary
Stops the Discord `webhook_token` (and decrypted vault vars) from leaking into verbose/Semaphore task output, and fixes a templating bug in the reboot handler.

- `tasks/notify.yml`: add `no_log: true` to the Discord task (keeps `ignore_errors`/`changed_when`).
- `handlers/main.yml`: add `no_log: true`; guard the IP field with `ansible_host | default(inventory_hostname)` to match `notify.yml` (hosts without `ansible_host` set no longer silently drop the reboot notice).
- `tasks/main.yml` + `tasks/report_pending_restarts.yml`: `no_log: true` on `include_vars: vault.yml`.

## Verification
- `ansible-playbook apply-patches.yml --syntax-check` ✅
- `ansible-playbook report-pending-restarts.yml --syntax-check` ✅

## Stack
First of 4 stacked PRs (base `main`): **A** → B → C → D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)