### PR TITLE
ci: add lint pipeline (yamllint + ansible-lint + syntax-check)

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,24 @@
+---
+profile: production
+
+exclude_paths:
+  - collections/
+  - roles/os-patching/tests/
+  # Encrypted ansible-vault file; ansible-lint cannot decrypt it to parse.
+  - roles/os-patching/vars/vault.yml
+
+# Rules skipped because they conflict with this role's deliberate design.
+skip_list:
+  # The role uses short, unprefixed vars (compose_exclude, reboot_enabled, etc.)
+  # by convention; it is a single application role, not a shared library.
+  - var-naming[no-role-prefix]
+  # Role dir is intentionally named "os-patching" (hyphen) to match the repo.
+  - role-name
+  # Patching a host TO the latest packages is the entire point of this role.
+  - package-latest
+  # Invariant: notification/reboot failures must never abort a patch run, so
+  # Discord and reboot tasks intentionally use ignore_errors instead of failing.
+  - ignore-errors
+  # The role's notification idiom fires include_tasks on a `when: *.changed`
+  # condition; these are deliberately tasks, not handlers.
+  - no-handler

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+---
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: yamllint + ansible-lint + syntax-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install lint tooling
+        run: pip install ansible ansible-lint yamllint
+
+      - name: Install pinned collections
+        run: ansible-galaxy collection install -r collections/requirements.yml
+
+      - name: yamllint
+        run: yamllint .
+
+      - name: ansible-lint
+        run: ansible-lint
+
+      - name: Syntax check (apply-patches.yml)
+        run: ansible-playbook apply-patches.yml --syntax-check
+
+      - name: Syntax check (report-pending-restarts.yml)
+        run: ansible-playbook report-pending-restarts.yml --syntax-check

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,23 @@
+---
+extends: default
+
+rules:
+  # Kept in sync with ansible-lint's embedded yamllint requirements.
+  braces:
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
+  line-length:
+    max: 160
+    level: warning
+  truthy:
+    allowed-values: ["true", "false", "yes", "no"]
+    check-keys: false
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false
+
+ignore: |
+  collections/
+  roles/os-patching/vars/vault.yml

--- a/apply-patches.yml
+++ b/apply-patches.yml
@@ -4,4 +4,4 @@
   become: yes
   serial: 1
   roles:
-    - { role: os-patching }
+    - role: os-patching

--- a/roles/os-patching/handlers/main.yml
+++ b/roles/os-patching/handlers/main.yml
@@ -10,5 +10,6 @@
           - name: Hostname
             value: "{{ inventory_hostname }}"
           - name: IP Address
-            value: "{{ ansible_host }}"
+            value: "{{ ansible_host | default(inventory_hostname) }}"
   ignore_errors: true
+  no_log: true

--- a/roles/os-patching/meta/main.yml
+++ b/roles/os-patching/meta/main.yml
@@ -1,3 +1,4 @@
+---
 galaxy_info:
   author: Chad Zimmerman
   description: Patch OS and Docker Container Images with a single role

--- a/roles/os-patching/tasks/main.yml
+++ b/roles/os-patching/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Prelim | Include Vaulted Variables
   ansible.builtin.include_vars: vault.yml
+  no_log: true
 
 - name: "Prelim | Verify need-restarting Command is Present on {{ inventory_hostname }}"
   ansible.builtin.dnf:

--- a/roles/os-patching/tasks/notify.yml
+++ b/roles/os-patching/tasks/notify.yml
@@ -16,3 +16,4 @@
                     + (embed_extra_fields | default([])) }}"
   ignore_errors: true
   changed_when: false
+  no_log: true

--- a/roles/os-patching/tasks/report_pending_restarts.yml
+++ b/roles/os-patching/tasks/report_pending_restarts.yml
@@ -4,6 +4,7 @@
 # restart. Intended to be run on a schedule (e.g. daily) as a recurring reminder.
 - name: "Prelim | Include Vaulted Variables"
   ansible.builtin.include_vars: vault.yml
+  no_log: true
 
 - name: "Prelim | Verify host has Docker installed"
   ansible.builtin.stat:


### PR DESCRIPTION
## Summary
Adds the first automated quality/security gate for the role.

- `.github/workflows/lint.yml`: on PRs and pushes to `main`, installs pinned collections then runs `yamllint`, `ansible-lint` (production profile), and `--syntax-check` on both playbooks.
- `.yamllint`: relaxed line-length (warning), allows the `yes/no` truthy values already in use, kept in sync with ansible-lint's embedded yamllint rules.
- `.ansible-lint`: production profile with `skip_list` entries that conflict with the role's deliberate design, each explained: `package-latest` (the role's whole purpose), `ignore-errors` (notify/reboot must never abort a run), `no-handler` (conditional-notify idiom), `role-name` (intentional hyphen), `var-naming[no-role-prefix]` (single-application role).

Fixes surfaced by the new gate: `apply-patches.yml` role entry → block style; `meta/main.yml` document-start marker.

## Verification
`yamllint .`, `ansible-lint`, and both `--syntax-check`s pass locally. ✅

## Stack
PR 2 of 4 (base `harden/no-log-secrets`): A → **B** → C → D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)