### PR TITLE
refactor: extract shared patch-status notify and reboot logic

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,24 @@
+---
+profile: production
+
+exclude_paths:
+  - collections/
+  - roles/os-patching/tests/
+  # Encrypted ansible-vault file; ansible-lint cannot decrypt it to parse.
+  - roles/os-patching/vars/vault.yml
+
+# Rules skipped because they conflict with this role's deliberate design.
+skip_list:
+  # The role uses short, unprefixed vars (compose_exclude, reboot_enabled, etc.)
+  # by convention; it is a single application role, not a shared library.
+  - var-naming[no-role-prefix]
+  # Role dir is intentionally named "os-patching" (hyphen) to match the repo.
+  - role-name
+  # Patching a host TO the latest packages is the entire point of this role.
+  - package-latest
+  # Invariant: notification/reboot failures must never abort a patch run, so
+  # Discord and reboot tasks intentionally use ignore_errors instead of failing.
+  - ignore-errors
+  # The role's notification idiom fires include_tasks on a `when: *.changed`
+  # condition; these are deliberately tasks, not handlers.
+  - no-handler

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+---
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: yamllint + ansible-lint + syntax-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install lint tooling
+        run: pip install ansible ansible-lint yamllint
+
+      - name: Install pinned collections
+        run: ansible-galaxy collection install -r collections/requirements.yml
+
+      - name: yamllint
+        run: yamllint .
+
+      - name: ansible-lint
+        run: ansible-lint
+
+      - name: Syntax check (apply-patches.yml)
+        run: ansible-playbook apply-patches.yml --syntax-check
+
+      - name: Syntax check (report-pending-restarts.yml)
+        run: ansible-playbook report-pending-restarts.yml --syntax-check

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,23 @@
+---
+extends: default
+
+rules:
+  # Kept in sync with ansible-lint's embedded yamllint requirements.
+  braces:
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
+  line-length:
+    max: 160
+    level: warning
+  truthy:
+    allowed-values: ["true", "false", "yes", "no"]
+    check-keys: false
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false
+
+ignore: |
+  collections/
+  roles/os-patching/vars/vault.yml

--- a/apply-patches.yml
+++ b/apply-patches.yml
@@ -4,4 +4,4 @@
   become: yes
   serial: 1
   roles:
-    - { role: os-patching }
+    - role: os-patching

--- a/roles/os-patching/defaults/main.yml
+++ b/roles/os-patching/defaults/main.yml
@@ -12,3 +12,7 @@ aur_helper: yay
 # When false, hosts are patched but never rebooted (reboot-required signals
 # persist, so a later run with reboot_enabled=true will reboot them).
 reboot_enabled: true
+# Per-host override: when true, the host is patched but never rebooted and no
+# reboot-pending notice is sent (e.g. workstations in the devices_net group,
+# set automatically in Archlinux.yml). Defaults false; most hosts reboot.
+reboot_skip: false

--- a/roles/os-patching/handlers/main.yml
+++ b/roles/os-patching/handlers/main.yml
@@ -10,5 +10,6 @@
           - name: Hostname
             value: "{{ inventory_hostname }}"
           - name: IP Address
-            value: "{{ ansible_host }}"
+            value: "{{ ansible_host | default(inventory_hostname) }}"
   ignore_errors: true
+  no_log: true

--- a/roles/os-patching/meta/main.yml
+++ b/roles/os-patching/meta/main.yml
@@ -1,3 +1,4 @@
+---
 galaxy_info:
   author: Chad Zimmerman
   description: Patch OS and Docker Container Images with a single role

--- a/roles/os-patching/tasks/Archlinux.yml
+++ b/roles/os-patching/tasks/Archlinux.yml
@@ -19,44 +19,22 @@
     upgrade_extra_args: "--noconfirm --needed"
   register: aur_results
 
-- name: "Notify Discord: patched"
-  ansible.builtin.include_tasks: notify.yml
+- name: "Notify Discord of patch status"
+  ansible.builtin.include_tasks: notify_patch_status.yml
   vars:
-    embed_title: "👍 {{ inventory_hostname }} was patched 👍"
-    embed_color: 1127128
-  when: pacman_results.changed or aur_results.changed
-
-- name: "Notify Discord: no patches required"
-  ansible.builtin.include_tasks: notify.yml
-  vars:
-    embed_title: "👍 No Patches were Required on {{ inventory_hostname }} 👍"
-    embed_color: 65280
-  when:
-    - not pacman_results.changed
-    - not aur_results.changed
+    patched: "{{ pacman_results.changed or aur_results.changed }}"
 
 - name: Check if a Reboot is Required
   ansible.builtin.command: /usr/bin/needrestart
   register: reboot_required
-  changed_when: no
+  changed_when: false
 
-- name: "Reboot the {{ inventory_hostname }}"
-  ansible.builtin.reboot:
-    post_reboot_delay: 30
-  when:
-    - "'Running kernel seems to be up-to-date.' not in reboot_required.stdout"
-    - "'No services need to be restarted.' not in reboot_required.stdout"
-    - not inventory_hostname in groups["devices_net"]
-    - reboot_enabled | bool
-  notify: Send Reboot Notification
+- name: "Determine reboot need on {{ inventory_hostname }}"
+  ansible.builtin.set_fact:
+    reboot_required_bool: >-
+      {{ 'Running kernel seems to be up-to-date.' not in reboot_required.stdout
+         and 'No services need to be restarted.' not in reboot_required.stdout }}
+    reboot_skip: "{{ inventory_hostname in groups['devices_net'] }}"
 
-- name: "Notify Discord: reboot pending"
-  ansible.builtin.include_tasks: notify.yml
-  vars:
-    embed_title: "⏳ Reboot Pending on {{ inventory_hostname }} ⏳"
-    embed_color: 16753920
-  when:
-    - "'Running kernel seems to be up-to-date.' not in reboot_required.stdout"
-    - "'No services need to be restarted.' not in reboot_required.stdout"
-    - not inventory_hostname in groups["devices_net"]
-    - not reboot_enabled | bool
+- name: "Reboot if required on {{ inventory_hostname }}"
+  ansible.builtin.include_tasks: reboot.yml

--- a/roles/os-patching/tasks/Debian.yml
+++ b/roles/os-patching/tasks/Debian.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Update APT Cache on {{ inventory_hostname }}"
   ansible.builtin.apt:
-    update_cache: yes
+    update_cache: true
   changed_when: false
 
 - name: "Update all APT packages on {{ inventory_hostname }}"
@@ -11,38 +11,19 @@
     autoclean: true
   register: apt_results
 
-- name: "Notify Discord: patched"
-  ansible.builtin.include_tasks: notify.yml
+- name: "Notify Discord of patch status"
+  ansible.builtin.include_tasks: notify_patch_status.yml
   vars:
-    embed_title: "👍 {{ inventory_hostname }} was patched 👍"
-    embed_color: 1127128
-  when: apt_results.changed
-
-- name: "Notify Discord: no patches required"
-  ansible.builtin.include_tasks: notify.yml
-  vars:
-    embed_title: "👍 No Patches were Required on {{ inventory_hostname }} 👍"
-    embed_color: 65280
-  when: not apt_results.changed
+    patched: "{{ apt_results.changed }}"
 
 - name: Check if a Reboot is Required
   ansible.builtin.stat:
     path: /var/run/reboot-required
   register: reboot_required
 
-- name: "Reboot {{ inventory_hostname }}"
-  ansible.builtin.reboot:
-    post_reboot_delay: 30
-  when:
-    - reboot_required.stat.exists
-    - reboot_enabled | bool
-  notify: Send Reboot Notification
+- name: "Determine reboot need on {{ inventory_hostname }}"
+  ansible.builtin.set_fact:
+    reboot_required_bool: "{{ reboot_required.stat.exists }}"
 
-- name: "Notify Discord: reboot pending"
-  ansible.builtin.include_tasks: notify.yml
-  vars:
-    embed_title: "⏳ Reboot Pending on {{ inventory_hostname }} ⏳"
-    embed_color: 16753920
-  when:
-    - reboot_required.stat.exists
-    - not reboot_enabled | bool
+- name: "Reboot if required on {{ inventory_hostname }}"
+  ansible.builtin.include_tasks: reboot.yml

--- a/roles/os-patching/tasks/RedHat.yml
+++ b/roles/os-patching/tasks/RedHat.yml
@@ -1,29 +1,23 @@
 ---
 - name: "Update DNF Cache on {{ inventory_hostname }}"
   ansible.builtin.dnf:
-    update_cache: yes
+    update_cache: true
   changed_when: false
 
 - name: "Update all DNF packages on {{ inventory_hostname }}"
   ansible.builtin.dnf:
     name: "*"
     state: latest
-    autoremove: true
   register: dnf_results
 
-- name: "Notify Discord: patched"
-  ansible.builtin.include_tasks: notify.yml
-  vars:
-    embed_title: "👍 {{ inventory_hostname }} was patched 👍"
-    embed_color: 1127128
-  when: dnf_results.changed
+- name: "Cleanup DNF cache on {{ inventory_hostname }}"
+  ansible.builtin.dnf:
+    autoremove: true
 
-- name: "Notify Discord: no patches required"
-  ansible.builtin.include_tasks: notify.yml
+- name: "Notify Discord of patch status"
+  ansible.builtin.include_tasks: notify_patch_status.yml
   vars:
-    embed_title: "👍 No Patches were Required on {{ inventory_hostname }} 👍"
-    embed_color: 65280
-  when: not dnf_results.changed
+    patched: "{{ dnf_results.changed }}"
 
 - name: Check if a Reboot is Required
   ansible.builtin.command: /usr/bin/needs-restarting -r
@@ -33,19 +27,9 @@
     - not reboot_required.rc == 0
     - not reboot_required.rc == 1
 
-- name: "Reboot {{ inventory_hostname }}"
-  ansible.builtin.reboot:
-    post_reboot_delay: 30
-  when:
-    - reboot_required.rc == 1
-    - reboot_enabled | bool
-  notify: Send Reboot Notification
+- name: "Determine reboot need on {{ inventory_hostname }}"
+  ansible.builtin.set_fact:
+    reboot_required_bool: "{{ reboot_required.rc == 1 }}"
 
-- name: "Notify Discord: reboot pending"
-  ansible.builtin.include_tasks: notify.yml
-  vars:
-    embed_title: "⏳ Reboot Pending on {{ inventory_hostname }} ⏳"
-    embed_color: 16753920
-  when:
-    - reboot_required.rc == 1
-    - not reboot_enabled | bool
+- name: "Reboot if required on {{ inventory_hostname }}"
+  ansible.builtin.include_tasks: reboot.yml

--- a/roles/os-patching/tasks/main.yml
+++ b/roles/os-patching/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Prelim | Include Vaulted Variables
   ansible.builtin.include_vars: vault.yml
+  no_log: true
 
 - name: "Prelim | Verify need-restarting Command is Present on {{ inventory_hostname }}"
   ansible.builtin.dnf:

--- a/roles/os-patching/tasks/notify.yml
+++ b/roles/os-patching/tasks/notify.yml
@@ -16,3 +16,4 @@
                     + (embed_extra_fields | default([])) }}"
   ignore_errors: true
   changed_when: false
+  no_log: true

--- a/roles/os-patching/tasks/notify_patch_status.yml
+++ b/roles/os-patching/tasks/notify_patch_status.yml
@@ -1,0 +1,17 @@
+---
+# Shared OS-patch result notification. Caller must set the boolean `patched`
+# (whether any package was upgraded). Emits the "patched" embed when true and
+# the "no patches required" embed when false.
+- name: "Notify Discord: patched"
+  ansible.builtin.include_tasks: notify.yml
+  vars:
+    embed_title: "👍 {{ inventory_hostname }} was patched 👍"
+    embed_color: 1127128
+  when: patched | bool
+
+- name: "Notify Discord: no patches required"
+  ansible.builtin.include_tasks: notify.yml
+  vars:
+    embed_title: "👍 No Patches were Required on {{ inventory_hostname }} 👍"
+    embed_color: 65280
+  when: not patched | bool

--- a/roles/os-patching/tasks/reboot.yml
+++ b/roles/os-patching/tasks/reboot.yml
@@ -1,0 +1,23 @@
+---
+# Shared reboot + reboot-pending notification. Caller must set the boolean
+# `reboot_required_bool` (does the OS report a reboot is needed). Honors
+# `reboot_enabled` (when false, never reboot — just notify) and `reboot_skip`
+# (when true, neither reboot nor notify — e.g. workstations that self-manage).
+- name: "Reboot {{ inventory_hostname }}"
+  ansible.builtin.reboot:
+    post_reboot_delay: 30
+  when:
+    - reboot_required_bool | bool
+    - reboot_enabled | bool
+    - not reboot_skip | bool
+  notify: Send Reboot Notification
+
+- name: "Notify Discord: reboot pending"
+  ansible.builtin.include_tasks: notify.yml
+  vars:
+    embed_title: "⏳ Reboot Pending on {{ inventory_hostname }} ⏳"
+    embed_color: 16753920
+  when:
+    - reboot_required_bool | bool
+    - not reboot_enabled | bool
+    - not reboot_skip | bool

--- a/roles/os-patching/tasks/report_pending_restarts.yml
+++ b/roles/os-patching/tasks/report_pending_restarts.yml
@@ -4,6 +4,7 @@
 # restart. Intended to be run on a schedule (e.g. daily) as a recurring reminder.
 - name: "Prelim | Include Vaulted Variables"
   ansible.builtin.include_vars: vault.yml
+  no_log: true
 
 - name: "Prelim | Verify host has Docker installed"
   ansible.builtin.stat:


### PR DESCRIPTION
## Summary
The "patched" / "no patches required" notify and the "reboot" / "reboot pending" blocks were triplicated across `Archlinux.yml`, `Debian.yml`, and `RedHat.yml`, differing only by which results var was checked and the reboot-detection mechanism. This extracts them into two shared task files.

- `tasks/notify_patch_status.yml` — driven by a `patched` boolean the caller sets.
- `tasks/reboot.yml` — driven by `reboot_required_bool` + `reboot_enabled` + a new `reboot_skip` flag (defaults `false`; Arch sets it from `devices_net` membership, preserving the old "workstations never reboot" behavior).
- Each per-OS file keeps only its cache/upgrade/cleanup and reboot-detection, then sets facts and includes the shared files. Carries the RedHat separate-autoremove "Cleanup DNF cache" task.
- `defaults/main.yml`: add `reboot_skip: false`.

**Behavior-preserving.** Reboot/notify truth tables verified against the original conditions (required×enabled×skip, plus Arch's string parse).

## Verification
`yamllint`, `ansible-lint` (production), and both `--syntax-check`s pass. ✅

## Stack
PR 3 of 4 (base `ci/lint-pipeline`): A → B → **C** → D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)