### PR TITLE
fix: robust Arch reboot detection via needrestart -b; refresh docs/meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,29 @@
-Role Name
-=========
+# os-patching
 
-This Ansible role will apply missing OS patches, send a notification via Discord web hook, and reboot the hosts.
+A single Ansible role that applies all available OS package updates, updates/restarts Docker Compose stacks, sends Discord notifications about what happened, and reboots the host if the OS reports a reboot is required. Hosts are patched one at a time (`serial: 1`) to ensure a reboot never takes out the whole fleet. Assumes the connecting user has **passwordless sudo**.
 
-- **NOTE:** Assumes a user account with passwordless sudo is used to execute the playbook
-
-Requirements
-------------
+## Requirements
 
 ### Collections
-  - community.general
-  - community.docker
 
-Dependencies
-------------
+- `community.general`
+- `community.docker`
 
-### Ansible Host
-  - Docker SDK for Python
-    - python3-docker is a typical package name
+Versions are pinned in `collections/requirements.yml`.
 
-### Inventory Hosts
-  - Docker and Docker-Compose
-    - debian 12 packages
-      - docker.io
-      - docker-compose
+### Control Node
 
-Role Variables
---------------
+- Docker SDK for Python (`python3-docker`)
+
+### Managed Hosts (Docker-enabled)
+
+- Docker
+- Docker Compose
+
+## Role Variables
 
 ### defaults/main.yml
+
 ```yaml
 ---
 discord_webhook_id: "{{ vault_discord_webhook_id }}"
@@ -38,19 +33,122 @@ discord_webhook_token: "{{ vault_discord_webhook_token }}"
 # controller's own stack (e.g. Semaphore), which must not be patched mid-run.
 compose_exclude:
   - /opt/stacks/semaphore
-
+aur_helper: yay
+# When false, hosts are patched but never rebooted (reboot-required signals persist).
+reboot_enabled: true
+# Per-host override: when true, the host is patched but never rebooted and no
+# reboot-pending notice is sent (e.g. workstations in the devices_net group).
+reboot_skip: false
 ```
 
-### vars/vault.yml
+**Variable Details:**
+
+- `discord_webhook_id` / `discord_webhook_token`: Mapped from vault secrets. Required for Discord notifications.
+- `compose_exclude`: List of Docker Compose stack directories to pull but never restart. Typically includes the automation controller's own stack (e.g. `/opt/stacks/semaphore`) — restarting it mid-run would break the playbook execution.
+- `aur_helper`: AUR wrapper used on Arch Linux (default `yay`). Used for patching AUR packages and installing `needrestart`.
+- `reboot_enabled`: Global toggle. When `false`, all hosts are patched but never rebooted. Reboot signals persist, so a later run with `reboot_enabled: true` will reboot them.
+- `reboot_skip`: Per-host override. When `true`, the host is patched but never rebooted and no reboot-pending notice is sent. Automatically set for hosts in the `devices_net` group on Arch Linux.
+
+### Secrets: vars/vault.yml
+
+`vars/vault.yml` is encrypted with `ansible-vault`. It exposes:
+
 ```yaml
 ---
 vault_discord_webhook_id: 0000000000000
 vault_discord_webhook_token: xxxxxxxxxxxxxxxx
-
 ```
 
-Example Inventory
------------------
+Edit with: `ansible-vault edit roles/os-patching/vars/vault.yml`
+
+## Per-OS Behavior
+
+### Package Upgrades
+
+- **Debian**: `apt full-upgrade`
+- **RedHat** (Fedora, EL): `dnf upgrade -y latest`
+- **Arch Linux**: `pacman -Syu` (system) + AUR via `{{ aur_helper }}` as `ansible_user`
+
+### Reboot Detection
+
+Reboot detection mechanism varies by OS:
+
+- **Debian**: Checks `/var/run/reboot-required`
+- **RedHat**: Runs `needs-restarting -r`; reboot when exit code is `1`
+- **Arch Linux**: Parses `needrestart -b NEEDRESTART-KSTA` output
+
+### Arch-Specific Behavior
+
+- AUR packages are patched as `ansible_user` via `{{ aur_helper }}` (default `yay`)
+- Hosts in the `devices_net` group (workstations) automatically skip reboot and do not send reboot-pending notices (set via `reboot_skip: true`)
+- The role pre-installs `needrestart` on Arch, and `dnf-utils` on RedHat
+
+## Docker Compose Handling
+
+Docker stacks are auto-discovered per host via `docker compose ls --format json`. The role partitions discovered stacks into two categories:
+
+1. **Fully Managed** (discovered minus `compose_exclude`): Images are pulled with `pull: always` and stacks are recreated (`docker compose up -d`).
+2. **Pull-Only** (discovered ∩ `compose_exclude`): Images are pulled but stacks are **never** restarted. This protects the automation controller's own stack from being torn down mid-run.
+
+### Pending-Restart Detection
+
+The role detects when stacks are running outdated images (drift-based): it compares each running container's image ID against the latest image ID locally available for its tag. A mismatch means a newer image was pulled but not applied. When detected, a Discord embed lists the stale stacks. This is self-clearing once `docker compose up -d` is run.
+
+## Discord Notifications
+
+The role sends Discord embeds for:
+
+- OS patches applied (with count)
+- OS patches not required (no-op)
+- Docker images updated (with count)
+- Stacks with pending restarts (drift detected)
+- Docker stack errors (if any)
+- Host reboot (if triggered)
+
+All notifications use the webhook credentials from `vault.yml`.
+
+## Commands
+
+### Install Collections
+
+```bash
+ansible-galaxy collection install -r collections/requirements.yml
+```
+
+### Apply Patches (Full Run)
+
+```bash
+ansible-playbook -i inventory.yml apply-patches.yml -K --ask-vault-pass
+```
+
+Flags:
+- `-K`: Prompt for become (sudo) password
+- `--ask-vault-pass`: Prompt for Ansible vault password
+- `--check`: Dry-run mode (add to preview changes)
+- `--limit <hostname>`: Run against a single host
+
+### Report Pending Restarts (Read-Only)
+
+```bash
+ansible-playbook -i inventory.yml report-pending-restarts.yml -K --ask-vault-pass
+```
+
+This reads-only playbook discovers stacks and reports (via Discord) any with outdated images. It does not patch, pull, or restart anything — safe to run as often as needed. Useful as a daily scheduled reminder.
+
+### Lint & Syntax Check
+
+```bash
+ansible-lint
+ansible-playbook apply-patches.yml --syntax-check
+```
+
+### Edit Encrypted Secrets
+
+```bash
+ansible-vault edit roles/os-patching/vars/vault.yml
+```
+
+## Example Inventory
 
 ```yaml
 ---
@@ -70,22 +168,8 @@ infrastructure:
           ansible_host: 10.10.111.200
 
 ```
-Example Playbook
-----------------
 
-`ansible-playbook -i inventory.yml apply-patches.yml -K --ask-vault-pass`
-
-```yaml
----
-- name: Update Infrastructure Nodes & Perform a reboot
-  hosts: all
-  roles:
-    - { role: os-patching }
-
-```
-
-Pending Restart Reminders
--------------------------
+## Pending Restart Reminders
 
 Stacks listed in `compose_exclude` (e.g. the automation controller's own stack) get their images
 pulled during patching but are never restarted automatically. `report-pending-restarts.yml` is a
@@ -113,12 +197,10 @@ Create a **separate template** for this playbook (don't reuse the patching templ
 The run is read-only — it never patches, pulls, or restarts — so it is safe to run as often as
 you like. It keeps re-sending the reminder until the stale stack is restarted.
 
-License
--------
+## License
 
 MIT
 
-Author Information
-------------------
+## Author
 
 [Chad Zimmerman](https://github.com/PrymalInstynct)

--- a/roles/os-patching/meta/main.yml
+++ b/roles/os-patching/meta/main.yml
@@ -6,19 +6,31 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: "2.10"
+  min_ansible_version: "2.15"
 
   platforms:
     - name: Fedora
       versions:
-        - "37"
-        - "38"
-        - "39"
         - "40"
+        - "41"
+        - "42"
+    - name: EL
+      versions:
+        - "9"
     - name: Debian
       versions:
         - "bookworm"
-        - "bullseye"
+        - "trixie"
     - name: ArchLinux
       versions:
         - all
+
+  galaxy_tags:
+    - patching
+    - updates
+    - security
+    - docker
+    - discord
+    - reboot
+
+dependencies: []

--- a/roles/os-patching/tasks/Archlinux.yml
+++ b/roles/os-patching/tasks/Archlinux.yml
@@ -25,15 +25,21 @@
     patched: "{{ pacman_results.changed or aur_results.changed }}"
 
 - name: Check if a Reboot is Required
-  ansible.builtin.command: /usr/bin/needrestart
+  ansible.builtin.command: needrestart -b
   register: reboot_required
   changed_when: false
 
 - name: "Determine reboot need on {{ inventory_hostname }}"
+  # needrestart -b prints a machine-readable NEEDRESTART-KSTA line (kernel
+  # status): 0 unknown, 1 current, 2 ABI-compatible upgrade pending, 3 version
+  # upgrade pending. A reboot is warranted for >= 2. This replaces locale- and
+  # version-fragile English stdout string matching.
   ansible.builtin.set_fact:
     reboot_required_bool: >-
-      {{ 'Running kernel seems to be up-to-date.' not in reboot_required.stdout
-         and 'No services need to be restarted.' not in reboot_required.stdout }}
+      {{ (reboot_required.stdout_lines
+          | select('match', '^NEEDRESTART-KSTA:')
+          | map('regex_replace', '^NEEDRESTART-KSTA:\s*', '')
+          | map('int') | first | default(0) | int) >= 2 }}
     reboot_skip: "{{ inventory_hostname in groups['devices_net'] }}"
 
 - name: "Reboot if required on {{ inventory_hostname }}"

--- a/roles/os-patching/tests/test.yml
+++ b/roles/os-patching/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - os_patching
+    - os-patching


### PR DESCRIPTION
## Summary
Replaces Arch's locale- and version-fragile English `needrestart` stdout string matching with batch mode, and refreshes stale docs/metadata.

- `Archlinux.yml`: run `needrestart -b` and parse the machine-readable `NEEDRESTART-KSTA` kernel status (0 unknown, 1 current, 2 ABI-compat upgrade, 3 version upgrade). Reboot warranted for **KSTA >= 2**. Verified against KSTA 1/2/3/absent.
- `README.md`: rewritten from the default scaffold to document actual behavior (`reboot_enabled`/`reboot_skip`/`aur_helper`, per-OS reboot detection, Docker auto-discovery + drift, the read-only report playbook), preserving the Example Inventory and Semaphore-scheduling sections.
- `meta/main.yml`: `min_ansible_version` 2.15, current Fedora/EL/Debian platforms, `galaxy_tags`, explicit empty `dependencies`.
- `tests/test.yml`: fix role reference `os_patching` → `os-patching`.

> ⚠️ **Intentional behavior refinement:** the old Arch logic only rebooted when the kernel needed updating **and** services needed restart (a quirky AND). Keying off `KSTA >= 2` bases the reboot decision purely on kernel status — the correct semantic for a patching role (services can be restarted without a reboot). Flag if you'd prefer the exact old condition.

## Verification
`yamllint`, `ansible-lint` (production), and both `--syntax-check`s pass. KSTA parse verified via a throwaway play. ✅

## Stack
PR 4 of 4 (base `refactor/dry-per-os`): A → B → C → **D**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)