### PR TITLE
ci: bump checkout@v5 and setup-python@v6 (Node 24)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary
Clears the Node.js 20 deprecation warning seen on the lint workflow. `actions/checkout@v4` and `actions/setup-python@v5` run on Node 20; GitHub **forces Node 24 on June 16th, 2026** and removes Node 20 on Sept 16th, 2026. Bumping to the Node 24 majors:

- `actions/checkout@v4` → `@v5`
- `actions/setup-python@v5` → `@v6`

No behavior change to the lint steps.

## Verification
`yamllint .github/workflows/lint.yml` passes; the workflow itself runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)