### PR TITLE
ci(renovate): track + auto-merge GitHub Actions digest/patch updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":disableRateLimiting",
     ":dependencyDashboard",
     ":semanticCommits",
@@ -14,6 +14,17 @@
   "suppressNotifications": ["prIgnoreNotification"],
   "rebaseWhen": "conflicted",
   "schedule": ["before 3am every weekday"],
+  "packageRules": [
+    {
+      // Group GitHub Actions digest/patch bumps into one PR and auto-merge
+      // them once CI passes (e.g. pinned-digest refreshes, v5.0.0 -> v5.0.1).
+      // Minor/major action updates still arrive as normal, reviewable PRs.
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest", "patch"],
+      "groupName": "github-actions",
+      "automerge": true
+    }
+  ],
   "ansible-galaxy": {
     "fileMatch": [
       "(^|/)requirements\\.ya?ml(\\.j2)?$",


### PR DESCRIPTION
## Summary
GitHub Actions were *already* tracked (the `github-actions` manager is on via `config:base`, and `helpers:pinGitHubActionDigests` pins + updates them) — Renovate just had no workflow file to act on until #88 landed. This tightens the behavior:

- Migrate the **deprecated** `config:base` preset → `config:recommended`.
- Add a `packageRules` entry for the `github-actions` manager that **groups digest/patch bumps into one PR** and **auto-merges them once CI passes** (e.g. pinned-digest refreshes, `v5.0.0` → `v5.0.1`). Minor/major action updates still arrive as normal, reviewable PRs.

## Effect
- Renovate's next run will pin `actions/checkout@v5` / `actions/setup-python@v6` to digests and keep them fresh automatically.
- Routine action maintenance becomes hands-off; only meaningful (minor/major) bumps need review.

> Note: auto-merge completes only if branch protection permits it (required checks pass; no blocking required-review rule). Adjust repo settings if you want it to merge unattended.

## Verification
`renovate-config-validator` → **Config validated successfully.** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)